### PR TITLE
Updated addmagazinecargo.txt

### DIFF
--- a/addmagazinecargo.txt
+++ b/addmagazinecargo.txt
@@ -1,129 +1,21 @@
-1 !item !part !rnd_ !food !dz_ !melee !blueprint !equip !empty !swing !hand !=10x_303 !=5x_22_LR_17_HMR !=AK_47_M !=AK_74 !=AKS_74_kobra !=AKS_74_U !=AmmoBoxSmall_556 !=AmmoBoxSmall_762 !=AngelCookies !=Attachment_ACG !=Attachment_AIM !=Attachment_CAMO !=Attachment_GL !=Attachment_Kobra !=Attachment_Pso !=Attachment_Silencer !=Attachment_sniper_scope !=Attachment_Sniper_Scope !=BAF_AS50_scoped !=BAF_L85A2_RIS_Holo !=BAF_L85A2_RIS_SUSAT !=Binocular !=Binocular_Vector !=bizon !=bizon_silenced !=Colt1911 !=Crossbow_DZ !=DMR_DZ !=DMR_DZ2 !=FlareGreen_M203 !=FlareWhite_M203 !=FN_FAL !=FN_FAL_ANPVS4 !=G36A !=G36A_camo !=G36A_CAMO !=G36C !=G36C_camo !=G36C_CAMO !=G36K !=G36K_camo !=G36K_CAMO !=glock17_EP1 !=huntingrifle !=LeeEnfield !=M1014 !=M107_DZ !=M14_EP1 !=M16A2 !=M16A2GL !=M16A4_ACG !=M24 !=M240_DZ !=M249_DZ !=M40A3 !=M4A1 !=M4A1_Aim !=M4A1_AIM !=M4A1_Aim_CAMO !=M4A1_AIM_SD_camo !=M4A1_HWS_GL !=M4A1_HWS_GL_camo !=M4A1_HWS_GL_CAMO !=M4A3_CCO_EP1 !=M9 !=M9SD !=Makarov !=MakarovSD !=MedBox0 !=Mk_48_DZ !=MP5A5 !=MP5SD !=MR43 !=NVGoggles !=PipeBomb !=Quiver !=Remington870_lamp !=revolver_EP1 !=RPK_74 !=Sa58P_EP1 !=Sa58V_CCO_EP1 !=Sa58V_EP1 !=Sa58V_RCO_EP1 !=SkinBase !=Skin_Camo1_DZ !=Skin_Sniper1_DZ !=Skin_Soldier1_DZ !=Skin_Survivor2_DZ !=SmokeShell !=SmokeShellGreen !=SmokeShellRed !=SVD !=SVD_CAMO !=TrapBear !=TrashJackDaniels !=TrashTinCan !=UZI_EP1 !=Winchester1866 !=WoodenArrow !=WoodenArrowF
-1 Melee !=MeleeBaseball !=MeleeBaseBallBat !=MeleeBaseBallBatBarbed !=MeleeBaseBallBatNails !=MeleeCrowbar !=MeleeFlashlight !=MeleeFlashlightRed !=MeleeHatchet !=MeleeMachete !=Melee_Swing !=WeaponHolder_MeleeBaseBallBat !=WeaponHolder_MeleeBaseBallBatNails !=WeaponHolder_MeleeBatBarbed !=WeaponHolder_MeleeMachete
-1 00Rnd_ !=100Rnd_762x51_M240 !=100Rnd_762x54_PK !=200Rnd_556x45_M249 !=200Rnd_762x51_M240
-1 0Rnd_ !00Rnd_ !=10Rnd_127x99_m107 !=10Rnd_762x54_SVD !=20Rnd_762x51_DMR !=20Rnd_762x51_FNFAL !=30Rnd_545x39_AK !=30Rnd_556x45_G36 !=30Rnd_556x45_G36SD !=30Rnd_556x45_Stanag !=30Rnd_556x45_StanagSD !=30Rnd_762x39_AK47 !=30Rnd_762x39_SA58 !=30Rnd_9x19_MP5 !=30Rnd_9x19_MP5SD !=30Rnd_9x19_UZI !=30Rnd_9x19_UZI_SD
-1 Rnd_ !0Rnd_ !=15Rnd_9x19_M9 !=15Rnd_9x19_M9SD !=15Rnd_W1866_Slug !=17Rnd_9x19_glock17 !=1Rnd_HE_M203 !=1Rnd_Smoke_M203 !=2Rnd_shotgun_74Pellets !=2Rnd_shotgun_74Slug !=5Rnd_127x99_as50 !=5Rnd_762x51_M24 !=64Rnd_9x19_Bizon !=64Rnd_9x19_SD_Bizon !=6Rnd_45ACP !=75Rnd_545x39_RPK !=7Rnd_45ACP_1911 !=8Rnd_9x18_Makarov !=8Rnd_9x18_MakarovSD !=8Rnd_B_Beneli_74Slug !=8Rnd_B_Beneli_Pellets !=8Rnd_B_Saiga12_74Slug !=8Rnd_B_Saiga12_Pellets
-1 Part !=equip_part_loupe !=PartEngine !=PartFueltank !=PartGeneric !=PartGlass !=PartVRotor !=PartWheel !=PartWoodPile !=WeaponHolder_PartEngine !=WeaponHolder_PartFueltank !=WeaponHolder_PartGeneric !=WeaponHolder_PartGlass !=WeaponHolder_PartVRotor !=WeaponHolder_PartWheel
-1 Item !Empty !=CraftingItem !=ItemAntibiotic !=ItemBandage !=ItemBloodbag !=ItemBookBible !=ItemCards !=ItemCompass !=ItemCrowbar !=ItemDomeTent !=ItemEpinephrine !=ItemEtool !=ItemFlashlight !=ItemFlashlightRed !=ItemFuelcan !=ItemGPS !=ItemHatchet !=ItemHeatPack !=ItemJerrycan !=ItemKnife !=ItemMachete !=ItemMap !=ItemMap_Debug !=ItemMatchbox !=ItemMorphine !=ItemNails !=ItemPainkiller !=ItemSandbag !=ItemShovel !=ItemSoda !=ItemSodaClays !=ItemSodaCoke !=ItemSodaDrwaste !=ItemSodaGrapeDrink !=ItemSodaLemonade !=ItemSodaLvg !=ItemSodaMdew !=ItemSodaMtngreen !=ItemSodaMzly !=ItemSodaPepsi !=ItemSodaR4z0r !=ItemSodaRabbit !=ItemSodaRocketFuel !=ItemSodaSmasht !=ItemTankTrap !=ItemTent !=ItemToolbox !=ItemTrashRazor !=ItemTrashToiletpaper !=ItemWatch !=ItemWaterbottle !=ItemWaterbottleBoiled !=ItemWaterbottleUnfilled !=ItemWire !=WeaponHolder_ItemCrowbar !=WeaponHolder_ItemFuelcan !=WeaponHolder_ItemHatchet !=WeaponHolder_ItemJerrycan !=WeaponHolder_ItemTent
-1 Item Empty !=ItemFuelcanEmpty !=ItemJerrycanEmpty !=ItemSodaClaysEmpty !=ItemSodaCokeEmpty !=ItemSodaDrwasteEmpty !=ItemSodaEmpty !=ItemSodaGrapeDrinkEmpty !=ItemSodaLemonadeEmpty !=ItemSodaLvgEmpty !=ItemSodaMdewEmpty !=ItemSodaMtngreenEmpty !=ItemSodaMzlyEmpty !=ItemSodaPepsiEmpty !=ItemSodaR4z0rEmpty !=ItemSodaRabbitEmpty !=ItemSodaRocketFuelEmpty !=ItemSodaSmashtEmpty
-1 FoodCan !Empty !=FoodCanBadguy !=FoodCanBakedBeans !=FoodCanBeef !=FoodCanBoneboy !=FoodCanCorn !=FoodCanCurgon !=FoodCanDemon !=FoodCanDerpy !=FoodCandyAnders !=FoodCandyChubby !=FoodCandyLegacys !=FoodCandyMintception !=FoodCanFraggleos !=FoodCanFrankBeans !=FoodCanGriff !=FoodCanHerpy !=FoodCanLongSprats !=FoodCanOrlok !=FoodCanPasta !=FoodCanPotatoes !=FoodCanPowell !=FoodCanRusCorn !=FoodCanRusMilk !=FoodCanRusPeas !=FoodCanRusPork !=FoodCanRusStew !=FoodCanRusUnlabeled !=FoodCanSardines !=FoodCanTylers !=FoodCanUnlabeled
-1 FoodCan Empty !=FoodCanBadguyEmpty !=FoodCanBeefEmpty !=FoodCanBoneboyEmpty !=FoodCanCornEmpty !=FoodCanCurgonEmpty !=FoodCanDemonEmpty !=FoodCanDerpyEmpty !=FoodCanFraggleosEmpty !=FoodCanGriffEmpty !=FoodCanHerpyEmpty !=FoodCanLongSpratsEmpty !=FoodCanOrlokEmpty !=FoodCanPotatoesEmpty !=FoodCanPowellEmpty !=FoodCanRusCornEmpty !=FoodCanRusMilkEmpty !=FoodCanRusPeasEmpty !=FoodCanRusPorkEmpty !=FoodCanRusStewEmpty !=FoodCanRusUnlabeledEmpty !=FoodCanTylersEmpty !=FoodCanUnlabeledEmpty
-1 Food !FoodCan !Empty !=FoodbaconCooked !=FoodbaconRaw !=FoodbeefCooked !=FoodbeefRaw !=FoodchickenCooked !=FoodchickenRaw !=FoodChipsChocolate !=FoodChipsMysticales !=FoodChipsSulahoops !=FoodCooked !=FoodgoatCooked !=FoodgoatRaw !=FoodmeatCooked !=FoodmeatRaw !=FoodMRE !=FoodmuttonCooked !=FoodmuttonRaw !=FoodNutmix !=FoodPistachio !=FoodrabbitCooked !=FoodrabbitRaw !=FoodRaw !=FoodSteakCooked !=FoodSteakRaw
-1 Food !FoodCan Empty !=FoodChipsChocolateEmpty !=FoodChipsMysticalesEmpty !=FoodChipsSulahoopsEmpty
-1 DZ_ !DZ_ALICE_Pack_EP1 !DZ_Assault_Pack_EP1 !DZ_Backpack_EP1 !DZ_British_ACU !DZ_CivilBackpack_EP1 !DZ_Czech_Vest_Puch !DZ_Patrol_Pack_EP1 !DZ_TK_Assault_Pack_EP1
-1 Blueprint !=Blueprint_Bandage !=Blueprint_BaseBallBatBarbed !=Blueprint_bizonSD !=Blueprint_Compass !=Blueprint_DMR_DZ2 !=Blueprint_G36A_camo !=Blueprint_G36C_camo !=Blueprint_G36K_camo !=Blueprint_M4A1_AIM !=Blueprint_M4A1_Aim_CAMO !=Blueprint_M4A1_HWS_GL_CAMO !=Blueprint_M9SD !=Blueprint_MAKAROVSD !=Blueprint_NailedBaseballBat !=Blueprint_SVD_CAMO
-1 equip !=equip_1inch_metal_pipe !=equip_2inch_metal_pipe !=equip_aa_battery !=equip_cable_tie !=equip_d_battery !=equip_duct_tape !=equip_empty_barrel !=equip_gauze !=equip_hose_clamp !=equip_laser !=equip_metal_sheet !=equip_nail !=equip_needle !=equip_note !=equip_paint !=equip_paper_sheet !=equip_part_loupe !=equip_pvc_box !=equip_rag !=equip_rail_screws !=equip_rope !=equip_scrap_electronics !=equip_scrap_metal !=equip_string !=equip_weapon_rails !=equip_wood_pallet
-1 swing !=BatBarbed_Swing !=BatBarbed_Swing_Ammo !=BatNails_Swing !=Bat_Swing !=Bat_Swing_Ammo !=crowbar_swing !=Crowbar_Swing !=Crowbar_Swing_Ammo !=hatchet_swing !=Hatchet_Swing !=Hatchet_Swing_Ammo !=Machete_swing !=Machete_Swing !=Machete_Swing_Ammo !=Melee_Swing
-1 hand !=HandChemBlue !=HandChemGreen !=HandChemRed !=HandGrenade_east !=HandGrenade_west !=HandRoadFlare
-
-// Blacklist of illegal weapons (not present in DayZ mod):
-5=A10
-5=AK_107_GL_kobra
-5=AK_107_GL_pso
-5=AK_107_kobra
-5=AK_107_pso
-5=AK_47_S
-5=AK_74_GL
-5=AK_74_GL_kobra
-5=AKS_74
-5=AKS_74_GOSHAWK
-5=AKS_74_NSPU
-5=AKS_74_pso
-5=AKS_74_UN_kobra
-5=AKS_GOLD
-//5=BAF_AS50_scoped // temporary enabled during 1.7.6.1 -> 1.7.7
-5=BAF_AS50_TWS
-5=BAF_ied_v1
-5=BAF_ied_v2
-5=BAF_ied_v3
-5=BAF_ied_v4
-5=BAF_L110A1_Aim
-5=BAF_L7A2_GPMG
-5=BAF_L85A2_RIS_ACOG
-5=BAF_L85A2_RIS_CWS
-5=BAF_L85A2_UGL_ACOG
-5=BAF_L85A2_UGL_Holo
-5=BAF_L85A2_UGL_SUSAT
-5=BAF_L86A2_ACOG
-5=BAF_LRR_scoped
-5=BAF_LRR_scoped_W
-// 5=Bizon  // referenced in dayzmod code
-5=G36_C_SD_eotech
-//5=G36a
-5=IR_Strobe_Marker
-5=IRStrobe
-5=ItemRadio
-5=ksvk
-5=Laserbatteries
-5=Laserdesignator
-5=m107
-//5=M107_DZ // temporary enabled during 1.7.6.1 -> 1.7.7
-5=M136
-5=m16a4
-5=M16A4_ACG_GL
-5=M16A4_GL
-5=M24_des_EP1
-5=M240
-5=m240_scoped_EP1
-5=M249
-5=M249_EP1
-5=M249_m145_EP1
-5=M32_EP1
-//5=M4A1_Aim_camo
-//5=M4A1_HWS_GL   // referenced in dayzmod code
-5=M4A1_HWS_GL_SD_Camo
-5=M4A1_RCO_GL
-5=M4A3_RCO_GL_EP1
-5=M4SPR
-5=M60A4_EP1
-5=m8_carbineGL
-5=MetisLauncher
-5=MG36
-5=Mk_48
-5=Mk_48_DES_EP1
-5=Pecheneg
-5=PK
-5=PMC_AS50_scoped
-5=PMC_ied_v1_muzzle
-5=PMC_ied_v2_muzzle
-5=PMC_ied_v3_muzzle
-5=PMC_ied_v4_muzzle
-5=revolver_gold_EP1
-5=RPG7V
-5=Sa61_EP1
-5=Saiga12K
-5=SCAR_H_CQC_CCO
-5=SCAR_H_LNG_Sniper
-5=SCAR_H_LNG_Sniper_SD
-5=SCAR_H_STD_EGLM_Spect
-5=SCAR_L_CQC
-5=SCAR_L_CQC_EGLM_Holo
-5=UZI_SD_EP1
-5=VSS_vintorez
-5=PMC_AS50_TWS
-5=ItemMap_Debug
-5=EvMoney
-5=ksvk
-5=HandGrenade
-5=PMC_AS50_TWS_Large
-//5=DMR // was in 1.7.6
-5=BAF_AS50_scoped_Large
-5=EvMap
-// Black list of illegal Ammo:
-5="TimeBomb"
-5="Mine"
-5="MineE"
-5="HandGrenade_Stone"
-5="R_SMAW_HEAA"
-5="R_SMAW_HEDP"
-5="Chukar"
-5=20Rnd_556x45_Stanag
-5=100Rnd_556x45_BetaCMag
-5=15Rnd_W1866_Pellet
-5=5Rnd_127x108_KSVK
-5=20Rnd_9x39_SP5_VSS
-5=100Rnd_556x45_M249
-5 "TWS"
-5=300Rnd_25mm_GAU12
-5=2000Rnd_23mm_AZP85
-5=10Rnd_9x39_SP5_VSS
+5 "" !"Item" !"Part" !"Rnd_" !"Food" !"Hand" !"Trash" !"Skin" !"Smoke" !"Flare" !"x_" !"Wood" !"_Swing" !="PipeBomb"
+5 "Item" !"Empty" !"Trash" !"Soda" !="ItemTent" !="ItemWaterbottleBoiled" !="ItemSandbag" !="ItemBloodbag" !="ItemJerrycan" !="ItemWaterbottleUnfilled" !="ItemFuelcan" !="ItemWire" !="ItemBandage" !="ItemHeatPack" !="ItemPainkiller" !="ItemBookBible" !="ItemMorphine" !="ItemCards" !="ItemAntibiotic" !="ItemTankTrap" !="ItemNails" !="ItemWaterbottle" !="ItemEpinephrine"
+1 "Soda" !"Empty" !="ItemSodaMzly" !="ItemSodaClays" !="ItemSodaLemonade" !="ItemSodaDrwaste" !="ItemSodaMdew" !="ItemSodaCoke" !="ItemSodaPepsi"
+5 "Part" !="PartWoodPile" !="PartEngine" !="PartGeneric" !="PartWheel" !="PartVRotor" !="PartFueltank" !="PartGlass"
+5 "00Rnd_" !="100Rnd_762x51_M240" !="200Rnd_556x45_M249" !="100Rnd_762x54_PK" !="200Rnd_762x51_M240"
+5 "0Rnd_" !"00Rnd_" !="20Rnd_762x51_FNFAL" !="10Rnd_762x54_SVD" !="30Rnd_9x19_UZI" !="30Rnd_762x39_SA58" !="30Rnd_9x19_MP5SD" !="30Rnd_556x45_G36" !="30Rnd_556x45_StanagSD" !="30Rnd_556x45_Stanag" !="30Rnd_545x39_AK" !="30Rnd_762x39_AK47" !="30Rnd_9x19_MP5" !="20Rnd_762x51_DMR"
+5 "Rnd_" !"0Rnd_" !="15Rnd_9x19_M9SD" !="8Rnd_9x18_MakarovSD" !="1Rnd_HE_M203" !="1Rnd_Smoke_M203" !="17Rnd_9x19_glock17" !="5Rnd_762x51_M24" !="15Rnd_W1866_Slug" !="6Rnd_45ACP" !="8Rnd_B_Beneli_Pellets" !="8Rnd_B_Beneli_74Slug" !="15Rnd_9x19_M9" !="2Rnd_shotgun_74Pellets" !="75Rnd_545x39_RPK" !="2Rnd_shotgun_74Slug" !="7Rnd_45ACP_1911" !="8Rnd_9x18_Makarov" !="64Rnd_9x19_SD_Bizon"
+5 "x_" !="10x_303" !="5x_22_LR_17_HMR"
+1 "FoodCan" !"Empty" !="FoodCanDemon" !="FoodCanBoneboy" !="FoodCandyLegacys" !="FoodCanRusPork" !="FoodCanRusPeas" !="FoodCanPowell" !="FoodCanTylers" !="FoodCanRusCorn" !="FoodCanBakedBeans" !="FoodCanPasta" !="FoodCanSardines" !="FoodCanFrankBeans" !="FoodCanRusUnlabeled" !="FoodCanBadguy" !="FoodCanRusStew" !="FoodCanDerpy" !="FoodCanRusMilk"
+1 "Food" !"FoodCan" !"Raw" !"Cooked" !="FoodNutmix" !="FoodMRE" !="FoodPistachio"
+5 "Raw" !="FoodrabbitRaw" !="FoodbeefRaw" !="FoodbaconRaw" !="FoodchickenRaw" !="FoodgoatRaw" !="FoodmuttonRaw" !="FoodSteakRaw"
+5 "Cooked" !="FoodrabbitCooked" !="FoodbeefCooked" !="FoodSteakCooked" !="FoodbaconCooked" !="FoodchickenCooked" !="FoodmuttonCooked" !="FoodgoatCooked"
+5 "Hand" !="HandRoadFlare" !="HandChemRed" !="HandChemGreen" !="HandChemBlue" !="HandGrenade_West" !="HandGrenade_East"
+5 "Trash" !="TrashTinCan" !="TrashJackDaniels" !="ItemTrashRazor" !="ItemTrashToiletpaper"
+5 "Skin" !="Skin_Sniper1_DZ" !="Skin_Camo1_DZ" !="Skin_Survivor2_DZ"
+5 "Smoke" !"Rnd_" !="SmokeShell" !="SmokeShellRed" !="SmokeShellGreen"
+5 "Flare" !"Hand" !="FlareWhite_M203" !="FlareGreen_M203"
+5 "Wood" !"Part" !="WoodenArrow"
+1 "Empty" !"Soda" !="ItemFuelcanEmpty" !="ItemJerrycanEmpty" !="FoodCanRusCornEmpty" !="FoodCanRusStewEmpty" !="FoodCanRusUnlabeledEmpty" !="FoodCanUnlabeledEmpty" !="FoodCanRusMilkEmpty" !="FoodCanRusPorkEmpty" !="FoodCanRusPeasEmpty"
+1 "Empty" !"Can" !="ItemSodaMzlyEmpty" !="ItemSodaDrwasteEmpty" !="ItemSodaMdewEmpty" !="ItemSodaEmpty" !="ItemSodaPepsiEmpty" !="ItemSodaCokeEmpty"
+1 "_Swing" !="Hatchet_Swing" !="Bat_Swing"


### PR DESCRIPTION
A more practical use of this filter. Instead of banning single items,
ban everything and filter what you want to allow.
Also Removed weapons from this file as they belong in the addweaponcargo.txt.
